### PR TITLE
Hide scroll indicators across web and native scroll views

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -28,10 +28,26 @@ export default function Root({ children }: { children: React.ReactNode }) {
 }
 
 const responsiveBackground = `
+html,
 body {
   background-color: #fff;
 }
+
+body,
+body * {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+body::-webkit-scrollbar,
+body *::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 @media (prefers-color-scheme: dark) {
+  html,
   body {
     background-color: #000;
   }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import React, {useEffect} from 'react';
 import {Stack, useRouter} from 'expo-router';
 import {StatusBar} from 'expo-status-bar';
 import {useFonts} from 'expo-font';
+import {FlatList, ScrollView, SectionList} from 'react-native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {GoogleSignin} from '../lib/googleSignIn';
@@ -12,6 +13,26 @@ import {queryClient} from '../lib/queryClient';
 import {AuthProvider, useAuth} from '../state/authProvider';
 import '../lib/fontPatch';
 import 'react-native-reanimated';
+
+type ScrollIndicatorDefaultsComponent = {
+  defaultProps?: Record<string, unknown>;
+};
+
+const hiddenScrollIndicatorDefaults = {
+  showsHorizontalScrollIndicator: false,
+  showsVerticalScrollIndicator: false,
+};
+
+function hideScrollIndicatorsByDefault(component: ScrollIndicatorDefaultsComponent) {
+  component.defaultProps = {
+    ...component.defaultProps,
+    ...hiddenScrollIndicatorDefaults,
+  };
+}
+
+hideScrollIndicatorsByDefault(ScrollView as ScrollIndicatorDefaultsComponent);
+hideScrollIndicatorsByDefault(FlatList as ScrollIndicatorDefaultsComponent);
+hideScrollIndicatorsByDefault(SectionList as ScrollIndicatorDefaultsComponent);
 
 GoogleSignin.configure({
   webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,

--- a/features/dashboard/screens/PresetsScreen.tsx
+++ b/features/dashboard/screens/PresetsScreen.tsx
@@ -976,6 +976,8 @@ function ReorderDisplaysModal({
               autoscrollSpeed={240}
               dragItemOverflow={false}
               scrollEnabled={draftDisplays.length * REORDER_ROW_HEIGHT > listHeight}
+              showsVerticalScrollIndicator={false}
+              showsHorizontalScrollIndicator={false}
               style={[styles.reorderList, {maxHeight: listHeight}]}
               contentContainerStyle={styles.reorderListContent}
               onDragBegin={index => setActiveId(draftDisplays[index]?.displayId ?? null)}


### PR DESCRIPTION
## Summary
- hide browser scrollbars globally in `app/+html.tsx`, including dark mode background handling on `html`
- disable scroll indicators by default for native `ScrollView`, `FlatList`, and `SectionList`
- explicitly hide indicators in the presets reorder list

## Testing
- Not run (not requested)